### PR TITLE
fix: rotator indicator gets hidden on large screens

### DIFF
--- a/src/component/Primitive/ResponsiveImage/index.jsx
+++ b/src/component/Primitive/ResponsiveImage/index.jsx
@@ -14,7 +14,8 @@ const ResponsiveImage = ({
   sizes,
   src,
   srcSet,
-  width
+  width,
+  className
 }) => (
   <img
     alt={alt}
@@ -26,6 +27,7 @@ const ResponsiveImage = ({
     src={src}
     sizes={sizes && sizes.join(',')}
     srcSet={srcSet && srcSetFormatter(srcSet)}
+    className={className}
   />
 )
 
@@ -38,7 +40,8 @@ ResponsiveImage.propTypes = {
   sizes: arrayOf(string),
   src: string.isRequired,
   srcSet: arrayOf(shape({ width: number.isRequired, src: string.isRequired })),
-  width: number.isRequired
+  width: number.isRequired,
+  className: string
 }
 
 export default ResponsiveImage

--- a/src/component/Primitive/Rotator/Rotator.module.scss
+++ b/src/component/Primitive/Rotator/Rotator.module.scss
@@ -3,6 +3,7 @@
   width: 100%;
   height: 100%;
   position: relative;
+  max-height: 100vh;
 }
 
 .RotatorContainer {
@@ -81,4 +82,9 @@
   justify-content: space-between;
   font-weight: bold;
   min-width: 140px;
+}
+
+.RotatorImage {
+  max-height: 100vh;
+  object-fit: contain;
 }

--- a/src/component/Primitive/Rotator/index.jsx
+++ b/src/component/Primitive/Rotator/index.jsx
@@ -154,6 +154,7 @@ const Rotator = ({
                   <div key={`RotatorImage${i}`}>
                     <ResponsiveImage
                       alt=""
+                      className={styles.RotatorImage}
                       srcSet={
                         image.srcSet &&
                         Object.entries(image.srcSet).map((src) => {

--- a/src/component/Primitive/ViewerCarousel/ViewerCarousel.module.scss
+++ b/src/component/Primitive/ViewerCarousel/ViewerCarousel.module.scss
@@ -2,6 +2,7 @@
   @import './vendor/swiper.scss';
 
   position: relative;
+  max-height: 100vh;
 }
 
 .ViewerCarouselPrimary {


### PR DESCRIPTION
The problem occurs because the images scale to fill the width of the frame and overflow when viewing the player on large screens.

Solution is to limit the height of the carousel/images to not exceed the screen (iframe) height and contain the image within the frame.

Before:
<img width="1467" alt="Screenshot 2023-03-30 at 16 27 27" src="https://user-images.githubusercontent.com/32732529/228868853-11433c70-5acc-402a-8246-f60bb0ddb4b2.png">


<img width="1433" alt="Screenshot 2023-03-30 at 16 20 26" src="https://user-images.githubusercontent.com/32732529/228866947-d9926112-b6ce-4820-874e-c99008579ddc.png">



After:
<img width="1473" alt="Screenshot 2023-03-30 at 16 26 52" src="https://user-images.githubusercontent.com/32732529/228868986-17806970-cdbb-4031-8d31-a36bdea1f76a.png">


![image](https://user-images.githubusercontent.com/32732529/228866449-e28412ee-ec80-4f0a-a879-e5c2e68fb8cc.png)